### PR TITLE
Position Claims Native as the AI front office

### DIFF
--- a/claimsnative/index.html
+++ b/claimsnative/index.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Claims Native | Offer insurance without hiring a billing team</title>
-  <meta name="description" content="Claims Native checks visits, prepares superbills or electronic claim drafts, and holds release until the practice records each required approval.">
+  <title>Start Accepting Insurance Without a Billing Department | Claims Native</title>
+  <meta name="description" content="Claims Native is the fully autonomous AI front office for cash-pay practices ready to accept insurance without hiring a biller or building billing operations.">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <link rel="canonical" href="https://atomandbits.com/claimsnative/">
   <meta property="og:type" content="website">
-  <meta property="og:title" content="Claims Native | Offer insurance without hiring a billing team">
-  <meta property="og:description" content="Check visits, prepare the next claim file, and keep each release under practice control.">
+  <meta property="og:title" content="Start accepting insurance without building a billing department">
+  <meta property="og:description" content="See what insured patients may be worth, then put claims, follow-up, denials, and reconciliation in one AI front office.">
   <meta property="og:url" content="https://atomandbits.com/claimsnative/">
   <meta property="og:image" content="https://atomandbits.com/og-2026-v3.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="Atom &amp; Bits — healthcare product leadership from payer rules to payment.">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Claims Native | Offer insurance without hiring a billing team">
-  <meta name="twitter:description" content="Check visits, prepare the next claim file, and keep each release under practice control.">
+  <meta name="twitter:title" content="Start accepting insurance without building a billing department">
+  <meta name="twitter:description" content="The fully autonomous AI front office for cash-pay practices ready to accept insurance.">
   <meta name="twitter:image" content="https://atomandbits.com/og-2026-v3.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -330,6 +330,15 @@
     }
 
     .calculator-result p { margin: 8px 0 0; color: #d9e4f1; font-size: 0.82rem; }
+    .calculator-result .button {
+      width: 100%;
+      margin-top: 18px;
+      border-color: var(--white);
+      background: var(--white);
+      color: var(--navy);
+    }
+    .calculator-result .button:hover { background: var(--blue-soft); }
+    .calculator-result small { display: block; margin-top: 8px; color: #d9e4f1; font-size: 0.72rem; }
     .calculator-note { margin: 0; padding: 0 20px 18px; color: var(--muted); font-size: 0.72rem; }
 
     .proof-strip {
@@ -532,6 +541,25 @@
 
     .pilot-panel p { color: var(--muted); }
 
+    .faq-list {
+      max-width: 900px;
+      margin: 0 auto;
+      border-top: 1px solid var(--line);
+    }
+
+    .faq-list details { border-bottom: 1px solid var(--line); }
+
+    .faq-list summary {
+      padding: 24px 42px 24px 0;
+      color: var(--navy);
+      font-family: Fraunces, Georgia, serif;
+      font-size: 1.3rem;
+      font-weight: 650;
+      cursor: pointer;
+    }
+
+    .faq-list details p { max-width: 780px; margin: -8px 0 24px; color: var(--muted); }
+
     .final-cta {
       padding: 94px 0;
       background: var(--navy);
@@ -630,7 +658,17 @@
         "url": "https://atomandbits.com/claimsnative/",
         "applicationCategory": "BusinessApplication",
         "operatingSystem": "Web",
-        "description": "Software for independent outpatient practices that checks visits, prepares claim files, enforces human approvals, and records each decision.",
+        "description": "The fully autonomous AI front office for cash-pay practices that want to start accepting insurance without hiring a biller or building billing operations.",
+        "audience": {
+          "@type": "Audience",
+          "audienceType": "Independent outpatient and specialty practices"
+        },
+        "featureList": [
+          "Insurance opportunity estimate",
+          "Insurance setup and payer readiness",
+          "Claim preparation, submission, and follow-up",
+          "Denial and payment reconciliation"
+        ],
         "creator": {"@id": "https://atomandbits.com/#organization"},
         "offers": {
           "@type": "Offer",
@@ -645,6 +683,46 @@
         "@id": "https://atomandbits.com/#organization",
         "name": "Atom & Bits, LLC",
         "url": "https://atomandbits.com/"
+      },
+      {
+        "@type": "Service",
+        "name": "Insurance Opportunity Review",
+        "url": "https://atomandbits.com/claimsnative/#review",
+        "provider": {"@id": "https://atomandbits.com/#organization"},
+        "audience": {
+          "@type": "Audience",
+          "audienceType": "Independent practices considering insurance"
+        },
+        "description": "A review that estimates missed patient revenue, maps the insurance work a practice would add, and identifies a narrow pilot path."
+      },
+      {
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Can a small practice accept insurance without hiring a biller?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Claims Native gives a cash-pay practice one fully autonomous AI front office to own insurance operations without requiring the practice to hire and manage a biller."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What work does accepting insurance add to a practice?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The work may include payer readiness, eligibility, claim preparation, submission, rejection and denial follow-up, remittance review, payment matching, patient balances, and posting."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Claims Native guarantee more revenue or reimbursement?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. The calculator is a planning estimate. Coverage, payer rules, denials, patient cost share, collection rates, displaced cash revenue, fees, and practice labor all affect the result."
+            }
+          }
+        ]
       }
     ]
   }
@@ -660,10 +738,10 @@
         <span>by Atom &amp; Bits</span>
       </a>
       <div class="nav-links">
-        <a href="#calculator">Calculator</a>
-        <a href="#how">How it works</a>
+        <a href="#calculator">Opportunity</a>
+        <a href="#how">The problem</a>
         <a href="#pilot">Paid pilot</a>
-        <a class="button" href="mailto:Ian@atomandbits.com?subject=Claims%20Native%2090-day%20pilot">Ask about the 90-day pilot</a>
+        <a class="button" href="#review">Get an opportunity review</a>
       </div>
     </div>
   </nav>
@@ -672,55 +750,57 @@
     <section class="hero">
       <div class="container hero-grid">
         <div>
-          <p class="eyebrow">Claims work for independent practices</p>
-          <h1>Offer insurance without hiring a billing team.</h1>
-          <p class="hero-copy"><span>Claims Native checks each visit against your rules.</span><span>It fixes safe errors and prepares the superbill or electronic claim draft.</span><span>It releases nothing until your office and provider approve it.</span><span>It records each rule, change, approval, and result.</span></p>
+          <p class="eyebrow">The fully autonomous AI front office for cash-pay practices</p>
+          <h1>Start accepting insurance without building a billing department.</h1>
+          <p class="hero-copy"><span>Cash-pay practices often turn away patients who want to use insurance.</span><span>Accepting them usually means hiring a biller or building an operation for claims, denials, follow-up, and reconciliation.</span><span>Claims Native handles that work through one fully autonomous AI front-office experience.</span></p>
           <div class="hero-actions">
-            <a class="button" href="#calculator">Calculate missed revenue <span aria-hidden="true">→</span></a>
-            <a class="button secondary" href="https://aether-research-us-01.tail598a94.ts.net/" rel="noopener">Open partner demo</a>
+            <a class="button" href="#calculator">See what insurance may be worth <span aria-hidden="true">→</span></a>
+            <a class="button secondary" href="#pilot">See the 90-day test</a>
           </div>
-          <p class="pilot-facts">90 days · $500 launch · $249/month · 200 visits/month</p>
-          <p class="microcopy">Built first for small outpatient practices using simple visit exports. Each specialty, practice rule, and payer path is configured before use.</p>
+          <p class="pilot-facts">Keep the patients · skip the billing department · see where the money stands</p>
+          <p class="microcopy">Start with one location and one insurance lane. Claims Native owns the operating queue while your practice keeps clinical and financial authority.</p>
         </div>
 
         <aside class="revenue-calculator" id="calculator" aria-labelledby="calculator-title">
-          <div class="calculator-head"><strong id="calculator-title">Estimate missed revenue</strong><span>Updates as you type</span></div>
+          <div class="calculator-head"><strong id="calculator-title">What might insurance be worth?</strong><span>Updates as you type</span></div>
           <div class="calculator-form">
             <div class="calculator-field-row">
-              <label for="lost-patients">Patients turned away<input id="lost-patients" type="number" inputmode="decimal" min="0" step="1" value="2"></label>
+              <label for="lost-patients">Insured patients turned away<input id="lost-patients" type="number" inputmode="decimal" min="0" step="1" value="2"></label>
               <label for="loss-period">How often?<select id="loss-period"><option value="day">Each workday</option><option value="week" selected>Each week</option><option value="month">Each month</option></select></label>
             </div>
             <label for="patient-value">Revenue per patient<input id="patient-value" type="number" inputmode="decimal" min="0" step="1" value="750"><small>Expected revenue across the full course of care</small></label>
           </div>
           <div class="calculator-result" aria-live="polite" aria-atomic="true">
-            <span>Estimated annual revenue missed</span>
-            <output id="annual-revenue" for="lost-patients loss-period patient-value">$78,000</output>
-            <p id="revenue-summary">About $6,500 each month from 104 patients a year.</p>
+            <span>Potential patient revenue turned away</span>
+            <output id="monthly-revenue" for="lost-patients loss-period patient-value">$6,500/month</output>
+            <p id="revenue-summary">About <strong id="annual-revenue">$78,000 a year</strong> from <span id="annual-patients">104</span> patients.</p>
+            <a class="button" id="review-cta" href="mailto:Ian@atomandbits.com?subject=Insurance%20Opportunity%20Review">Get an Insurance Opportunity Review <span aria-hidden="true">→</span></a>
+            <small>Opens a prefilled email with your estimate.</small>
           </div>
-          <p class="calculator-note">Planning estimate only. Uses 260 workdays, 52 weeks, or 12 months and does not account for payer rules, denials, patient cost share, collection rates, or added costs.</p>
+          <p class="calculator-note">Planning estimate only, not a revenue promise. This is gross potential patient revenue, not net income. It uses 260 workdays, 52 weeks, or 12 months and does not account for coverage, payer rules, denials, patient cost share, collection rates, displaced cash revenue, or added costs.</p>
         </aside>
       </div>
     </section>
 
-    <div class="proof-strip" aria-label="Claims Native operating principles">
-      <div class="proof"><strong>25–100 visits/week</strong><span>Purpose-built for an independent outpatient practice.</span></div>
-      <div class="proof"><strong>Two approvals</strong><span>Office and provider approve the same version.</span></div>
-      <div class="proof"><strong>Superbill first</strong><span>Electronic paths open as enrollment permits.</span></div>
-      <div class="proof"><strong>No invented diagnoses</strong><span>Missing clinical evidence stops the claim.</span></div>
+    <div class="proof-strip" aria-label="Claims Native business outcomes">
+      <div class="proof"><strong>Find missed revenue</strong><span>Estimate the insured patients your practice turns away.</span></div>
+      <div class="proof"><strong>Start without hiring</strong><span>Add an insurance lane without adding billing payroll.</span></div>
+      <div class="proof"><strong>Put the queue on autopilot</strong><span>Claims, follow-up, denials, and reconciliation move through one front office.</span></div>
+      <div class="proof"><strong>See where cash stands</strong><span>Know what moved, what stopped, and what comes next.</span></div>
     </div>
 
     <section class="section" id="how">
       <div class="container">
         <div class="section-head">
-          <div><p class="eyebrow">From visits to a claim package</p><h2>Offer insurance without adding a claims department.</h2></div>
-          <p class="section-intro">Claims Native routes, checks, and prepares each visit under the rules you set. Your team sees the result, the source, and the one decision that needs a person.</p>
+          <div><p class="eyebrow">The cash-pay practice problem</p><h2>You want to accept insurance. You do not want to build a billing operation.</h2></div>
+          <p class="section-intro">The risk is not one more tool. It is hiring a biller and managing payer rules, claim follow-up, denials, and payment work before you know whether insurance will pay off.</p>
         </div>
 
         <div class="steps">
-          <article class="step"><span class="step-number">01 · Import</span><h3>Upload the day</h3><p>Upload a Jane-style visit export. Claims Native checks every row and shows each bad row.</p></article>
-          <article class="step"><span class="step-number">02 · Prepare</span><h3>Check and prepare</h3><p>Claims Native loads your rules, checks the claim, fixes safe errors, and prepares the next allowed file.</p></article>
-          <article class="step"><span class="step-number">03 · Review</span><h3>Review the evidence</h3><p>The office and provider see what changed, why the claim stopped, and what each approval allows.</p></article>
-          <article class="step"><span class="step-number">04 · Release</span><h3>Release the approved result</h3><p>After each required approval, Claims Native releases a printable superbill or a clearly marked electronic dry run.</p></article>
+          <article class="step"><span class="step-number">01 · Missed revenue</span><h3>Insured patients go elsewhere</h3><p>People may never book, or they leave when they learn the practice is cash-pay.</p></article>
+          <article class="step"><span class="step-number">02 · Added payroll</span><h3>A biller becomes a fixed cost</h3><p>You must hire, train, manage, and cover billing work before the new revenue is clear.</p></article>
+          <article class="step"><span class="step-number">03 · Added operation</span><h3>Every visit starts payer work</h3><p>Eligibility, claims, corrections, rejections, denials, and follow-up all need an owner.</p></article>
+          <article class="step"><span class="step-number">04 · Harder cash</span><h3>Payments must match the work</h3><p>Remittances, deposits, patient balances, and posting must agree before you know what you collected.</p></article>
         </div>
       </div>
     </section>
@@ -728,23 +808,39 @@
     <section class="section alt" id="control">
       <div class="container">
         <div class="section-head">
-          <div><p class="eyebrow">Rules and decisions in one place</p><h2>Keep your rules, approvals, and claim history in one place.</h2></div>
-          <p class="section-intro">Claims Native keeps each SOP, fee, payer rule, correction, approval, and result beside the claim. It cannot release a claim before the practice records each required approval.</p>
+          <div><p class="eyebrow">The AI front office for insurance</p><h2>One front office moves the work from patient to payment.</h2></div>
+          <p class="section-intro">Claims Native owns the operating queue, completes routine work, routes exceptions behind the scenes, and gives your practice one clear view of the result.</p>
         </div>
 
         <div class="trust-grid">
-          <article class="trust-card featured"><h3>Your practice keeps the final say.</h3><span class="trust-rule">Office approval + provider approval + unchanged claim version</span></article>
-          <article class="trust-card"><h3>Keep the source beside the decision</h3><p>Source data, service lines, corrections, fees, payer rules, SOPs, and prior decisions stay beside the recommendation.</p></article>
-          <article class="trust-card"><h3>Name each state truthfully</h3><p>A dry run stays a dry run. Prepared, released, submitted, accepted, denied, and paid keep their exact meanings.</p></article>
+          <article class="trust-card featured"><h3>The work moves without you chasing it.</h3><span class="trust-rule">Patient + payer + claim + follow-up + payment</span></article>
+          <article class="trust-card"><h3>Your team gets decisions, not billing queues</h3><p>The AI front office handles the routine path and brings your practice only the clinical or financial choices it must make.</p></article>
+          <article class="trust-card"><h3>Revenue stays visible</h3><p>Submitted, accepted, denied, paid, and posted remain separate. You can see what happened and what comes next.</p></article>
         </div>
       </div>
     </section>
 
-    <section class="section" id="pilot">
+    <section class="section" id="approach">
       <div class="container">
         <div class="section-head">
-          <div><p class="eyebrow">90-day pilot</p><h2>Test the work for 90 days before you add volume.</h2></div>
-          <p class="section-intro">We start with one practice, named approvers, one visit-export format, and a small set of claim paths. The pilot tests whether the team can release the right file with less office work.</p>
+          <div><p class="eyebrow">A measured first step</p><h2>Start with one insurance lane. Let Claims Native run it.</h2></div>
+          <p class="section-intro">We set up a narrow path, then the AI front office owns the day-to-day flow while your practice measures the value.</p>
+        </div>
+
+        <div class="steps">
+          <article class="step"><span class="step-number">01 · Size</span><h3>Estimate the opportunity</h3><p>Count the insured patients you turn away and estimate the gross patient revenue they may represent.</p></article>
+          <article class="step"><span class="step-number">02 · Set up</span><h3>Choose one insurance lane</h3><p>Set the location, payer path, visit flow, practice rules, and required decisions.</p></article>
+          <article class="step"><span class="step-number">03 · Run</span><h3>Put the work in motion</h3><p>Claims Native owns the queue across claim work, follow-up, denials, payment evidence, and reconciliation.</p></article>
+          <article class="step"><span class="step-number">04 · Measure</span><h3>Judge net value</h3><p>Compare collected revenue, practice time, fees, and unresolved work before you expand.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section alt" id="pilot">
+      <div class="container">
+        <div class="section-head">
+          <div><p class="eyebrow">90-day pilot</p><h2>Spend 90 days testing insurance revenue, not recruiting a biller.</h2></div>
+          <p class="section-intro">The pilot lets a cash-pay practice start an insurance lane through one AI front office. We keep the first lane narrow so the economics stay visible.</p>
         </div>
 
         <div class="pilot-grid">
@@ -753,29 +849,46 @@
             <ul class="fit-list">
               <li>Independent outpatient or specialty practice</li>
               <li>Roughly 25–100 visits per week</li>
-              <li>Cash-only today or newly adding insurance</li>
+              <li>Cash-pay today and ready to begin accepting insurance</li>
               <li>Jane or another export-friendly practice system</li>
-              <li>Small administrative team, no claims department</li>
+              <li>Does not want to hire a biller or build billing operations</li>
               <li>Named office and clinical approvers</li>
             </ul>
           </article>
 
           <article class="pilot-panel">
-            <h3>One clear first step</h3>
-            <p>Guided setup covers one location, one visit-export format, two approvers, up to 200 visits per month, superbill release, dry-run claim paths, and one weekly review. Additional visits cost $1.25 each.</p>
+            <h3>Insurance Opportunity Review</h3>
+            <p>First, we review your estimate and map the added work. If the numbers and workflow fit, guided setup covers one location, one insurance lane, two named decision-makers, up to 200 visits per month, and one weekly performance review. Additional visits cost $1.25 each.</p>
             <div class="price"><strong>$500 guided launch</strong><span>then $249/month · 90-day founding pilot</span></div>
-            <a class="button" href="mailto:Ian@atomandbits.com?subject=Claims%20Native%20founding-practice%20pilot">Ask about the pilot <span aria-hidden="true">→</span></a>
-            <p class="microcopy">No percentage of collections. No guarantee of reimbursement, payer acceptance, or legal correctness. Live electronic transmission requires enrollment, credentials, and explicit configuration; the current default is a non-transmitted dry run.</p>
+            <a class="button" href="mailto:Ian@atomandbits.com?subject=Insurance%20Opportunity%20Review">Get an Insurance Opportunity Review <span aria-hidden="true">→</span></a>
+            <p class="microcopy">No percentage of collections. No guarantee of reimbursement, payer acceptance, or legal correctness. Results depend on payer enrollment, coverage, service mix, patient responsibility, and practice decisions.</p>
           </article>
         </div>
       </div>
     </section>
 
-    <section class="final-cta">
+    <section class="section" id="questions">
       <div class="container">
-        <h2>Offer insurance without giving up control.</h2>
-        <p>Bring one day of visits. We will show what Claims Native can prepare, what still needs a person, and whether the 90-day pilot fits.</p>
-        <a class="button" href="mailto:Ian@atomandbits.com?subject=Claims%20Native%2090-day%20pilot">Ask about the 90-day pilot <span aria-hidden="true">→</span></a>
+        <div class="section-head">
+          <div><p class="eyebrow">Questions before you accept insurance</p><h2>Know what you are taking on.</h2></div>
+          <p class="section-intro">The review is meant to make the revenue, cost, work, and limits clear before you change how the practice operates.</p>
+        </div>
+
+        <div class="faq-list">
+          <details><summary>Can a small practice accept insurance without hiring a biller?</summary><p>Yes. Claims Native gives a cash-pay practice one fully autonomous AI front office to own insurance operations without requiring the practice to hire and manage a biller.</p></details>
+          <details><summary>What work does accepting insurance add to a practice?</summary><p>The work may include payer readiness, eligibility, claim preparation, submission, rejection and denial follow-up, remittance review, payment matching, patient balances, and posting.</p></details>
+          <details><summary>Does Claims Native handle billing and reconciliation?</summary><p>Claims Native serves as the AI front office. It coordinates payer setup, claim work, follow-up, denials, payment evidence, and reconciliation. When judgment is needed, it routes the exception behind the scenes and keeps your practice focused on the decision.</p></details>
+          <details><summary>Does Claims Native guarantee more revenue or reimbursement?</summary><p>No. The calculator is a planning estimate. Coverage, payer rules, denials, patient cost share, collection rates, displaced cash revenue, fees, and practice labor all affect the result.</p></details>
+          <details><summary>What does the 90-day pilot test?</summary><p>It tests one narrow claim path with real practice data. The practice measures collected revenue, office time, fees, and unresolved work before it decides whether to expand.</p></details>
+        </div>
+      </div>
+    </section>
+
+    <section class="final-cta" id="review">
+      <div class="container">
+        <h2>Start accepting insurance without building the billing operation.</h2>
+        <p>Bring your estimate and one day of visits. We will map the revenue opportunity and the first insurance lane for your AI front office.</p>
+        <a class="button" href="mailto:Ian@atomandbits.com?subject=Insurance%20Opportunity%20Review">Get an Insurance Opportunity Review <span aria-hidden="true">→</span></a>
       </div>
     </section>
   </main>
@@ -791,8 +904,10 @@
       var patientsInput = document.getElementById('lost-patients');
       var periodInput = document.getElementById('loss-period');
       var valueInput = document.getElementById('patient-value');
+      var monthlyOutput = document.getElementById('monthly-revenue');
       var annualOutput = document.getElementById('annual-revenue');
-      var summaryOutput = document.getElementById('revenue-summary');
+      var annualPatientsOutput = document.getElementById('annual-patients');
+      var reviewCta = document.getElementById('review-cta');
       var factors = { day: 260, week: 52, month: 12 };
       var money = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
       var number = new Intl.NumberFormat('en-US', { maximumFractionDigits: 1 });
@@ -802,12 +917,41 @@
         return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
       }
 
+      function getAttribution() {
+        var params = new URLSearchParams(window.location.search);
+        var campaign = [params.get('utm_source'), params.get('utm_medium'), params.get('utm_campaign')].filter(Boolean);
+        if (campaign.length) return campaign.join(' / ');
+        if (document.referrer) {
+          try { return new URL(document.referrer).hostname; } catch (error) { return 'Referral'; }
+        }
+        return 'Direct or unknown';
+      }
+
       function updateEstimate() {
         var annualPatients = safeNumber(patientsInput) * factors[periodInput.value];
         var annualRevenue = annualPatients * safeNumber(valueInput);
-        annualOutput.value = money.format(annualRevenue);
-        annualOutput.textContent = money.format(annualRevenue);
-        summaryOutput.textContent = 'About ' + money.format(annualRevenue / 12) + ' each month from ' + number.format(annualPatients) + ' patients a year.';
+        var monthlyRevenue = annualRevenue / 12;
+        var subject = 'Insurance Opportunity Review — ' + money.format(monthlyRevenue) + '/month estimate';
+        var body = [
+          'I used the Claims Native opportunity calculator.',
+          '',
+          'Estimated potential patient revenue: ' + money.format(monthlyRevenue) + '/month (' + money.format(annualRevenue) + '/year)',
+          'Assumption: ' + number.format(safeNumber(patientsInput)) + ' insured patients turned away each ' + periodInput.value + ' at ' + money.format(safeNumber(valueInput)) + ' per patient.',
+          'Attribution: ' + getAttribution(),
+          '',
+          'Practice name:',
+          'Specialty:',
+          'City/state:',
+          'Insurance today (cash only, superbill, mixed, or in-network):',
+          'Biggest concern about accepting insurance:',
+          'Best contact:'
+        ].join('\n');
+
+        monthlyOutput.value = money.format(monthlyRevenue) + '/month';
+        monthlyOutput.textContent = money.format(monthlyRevenue) + '/month';
+        annualOutput.textContent = money.format(annualRevenue) + ' a year';
+        annualPatientsOutput.textContent = number.format(annualPatients);
+        reviewCta.href = 'mailto:Ian@atomandbits.com?subject=' + encodeURIComponent(subject) + '&body=' + encodeURIComponent(body);
       }
 
       [patientsInput, periodInput, valueInput].forEach(function (input) {

--- a/docs/research/claims-native-seo-geo-positioning-2026-08-19.md
+++ b/docs/research/claims-native-seo-geo-positioning-2026-08-19.md
@@ -1,0 +1,84 @@
+# Claims Native website positioning for search and AI answers
+
+Date: 2026-08-19
+
+## Decision
+
+Lead with the buyer's business problem:
+
+> Start accepting insurance without building a billing department.
+
+The site should show this sequence:
+
+1. A cash-pay practice wants to start accepting insurance.
+2. It does not want to hire a biller or build a billing operation.
+3. Accepting insurance adds claims, denials, follow-up, and payment reconciliation.
+4. Claims Native gives the practice one fully autonomous AI front office that owns the operating queue.
+5. The pilot measures collected revenue, practice time, fees, and unresolved work before expansion.
+
+Lead with the cash-pay practice problem. Present the fully autonomous AI front office as the answer. Keep EDI, data models, control states, and claim-file formats out of the opening message.
+
+## Positioning
+
+**Category:** The fully autonomous AI front office for insurance.
+
+**Plain-language category:** Insurance operations for cash-pay practices without a billing department.
+
+**Core promise:** Claims Native helps cash-pay practices start accepting insurance without hiring a biller or building billing operations.
+
+**Experience:** Claims Native owns the insurance operating queue through one fully autonomous front-office experience. Human operations may support the work behind the scenes without becoming another team the practice must hire and manage.
+
+**Reason to believe:** A controlled pilot starts with the practice's real visit flow, rules, named decision-makers, and one insurance lane. It measures work and outcomes before expansion.
+
+## Search intent map
+
+These are intent hypotheses, not search-volume claims.
+
+| Page role | Buyer question | Natural target language |
+| --- | --- | --- |
+| Product page | How can my cash-pay practice start accepting insurance without hiring a biller? | accept insurance without a biller; start accepting insurance in a cash-pay practice; AI front office for insurance |
+| Opportunity calculator | How much revenue am I losing by not taking insurance? | insurance revenue calculator; patients turned away because of insurance |
+| Guide | What does it cost a small practice to accept insurance? | cost of accepting insurance; medical billing overhead for small practices |
+| Guide | What work starts after a practice accepts insurance? | medical billing workflow; claim follow-up; denial management; payment reconciliation |
+| Comparison | Should I hire, outsource, or use a platform? | in-house vs outsourced medical billing; medical billing service alternatives |
+| Pilot page | How can I test insurance before changing my whole practice? | medical billing pilot; start accepting insurance in a private practice |
+
+The first page should answer the product question and link to the calculator. Supporting guides should be added only when they contain first-hand operating detail, examples, measured pilot findings, or useful decision tools.
+
+## SEO and generative search guidance
+
+Google says AI Overviews and AI Mode use the same foundational search requirements as the rest of Google Search. Pages must be crawlable, indexed, eligible for snippets, internally linked, useful to people, and clear in text. Google says there is no special schema or machine-readable file required for its AI features. [Google: AI features and your website](https://developers.google.com/search/docs/appearance/ai-features)
+
+Google's generative-search guide treats GEO and AEO as SEO, not as separate systems to game. It recommends unique, expert-led, non-commodity content and warns against thin query-variant pages, AI-only rewrites, inauthentic mentions, and overreliance on structured data. It also says `llms.txt` does not help or hurt visibility in Google Search. [Google: optimizing for generative AI features](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide)
+
+Google's people-first guidance favors original information, clear authorship and expertise, a focused site purpose, and content that fully answers the visitor's task. Claims Native should publish operating evidence from real pilots rather than broad billing summaries that any competitor could write. [Google: helpful, reliable, people-first content](https://developers.google.com/search/docs/fundamentals/creating-helpful-content)
+
+OpenAI says public pages can appear in ChatGPT search and recommends allowing `OAI-SearchBot` so content can be discovered, summarized, cited, and linked. It also documents `utm_source=chatgpt.com` on referral URLs for measurement. [OpenAI: publishers and developers FAQ](https://help.openai.com/en/articles/12627856-publishers-and-developers-faq)
+
+Perplexity recommends allowing `PerplexityBot` for pages to surface and link in Perplexity search results. The site's current `User-agent: *` rule already allows it. [Perplexity crawler documentation](https://docs.perplexity.ai/docs/resources/perplexity-crawlers)
+
+## Technical changes for the product page
+
+- Use a title and description centered on accepting insurance without a billing department.
+- Put the monthly opportunity and the Insurance Opportunity Review in the first screen.
+- Use one descriptive H1 and question-led H2 sections.
+- Keep the buyer problem, autonomous experience, workflow, and pilot terms in server-delivered HTML.
+- Keep canonical, index/follow, Open Graph, and Twitter metadata aligned with visible copy.
+- Keep `SoftwareApplication` and `Organization` structured data aligned with the page. Add visible FAQ content before adding `FAQPage` data.
+- Keep `OAI-SearchBot` allowed. The wildcard rule already allows Googlebot, PerplexityBot, and Claude's robots-respecting crawlers.
+- Do not add `llms.txt` as an SEO measure.
+- Update the sitemap date because the product page changed materially.
+
+## Measurement
+
+Measure business evidence, not impressions alone:
+
+1. Calculator-to-review conversion.
+2. Review requests from qualified independent practices.
+3. Completed reviews with a confirmed operating problem.
+4. Practices willing to share a sample workflow or data.
+5. Pilot requests and paid pilots.
+6. Search Console queries and pages that produce qualified requests.
+7. Referrals from ChatGPT and other answer engines when the referrer is available.
+
+The build threshold should stay tied to repeated buyer evidence: at least two pilot requests, one paid pilot, and the same workflow problem in at least three completed reviews.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -16,7 +16,7 @@
   <url><loc>https://atomandbits.com/healthcare-ai-operations/</loc><lastmod>2026-07-22</lastmod></url>
   <url><loc>https://atomandbits.com/healthcare-ai-workflow-assessment/</loc><lastmod>2026-07-22</lastmod></url>
   <url><loc>https://atomandbits.com/guides/how-to-choose-a-healthcare-cto/</loc><lastmod>2026-07-20</lastmod></url>
-  <url><loc>https://atomandbits.com/claimsnative/</loc><lastmod>2026-07-20</lastmod></url>
+  <url><loc>https://atomandbits.com/claimsnative/</loc><lastmod>2026-08-19</lastmod></url>
   <url><loc>https://atomandbits.com/privacy-policy.html</loc><lastmod>2026-07-20</lastmod></url>
   <url><loc>https://atomandbits.com/support.html</loc><lastmod>2026-07-20</lastmod></url>
 </urlset>


### PR DESCRIPTION
## What changed

- Reframed the page for cash-pay practices that want to start accepting insurance without hiring a biller or building billing operations.
- Positioned Claims Native as the fully autonomous AI front office for claims, follow-up, denials, and reconciliation.
- Turned the calculator result into a prefilled Insurance Opportunity Review request.
- Added source attribution for search, ChatGPT, referrals, and campaigns.
- Added problem-led FAQ content, aligned metadata and structured data, and updated the sitemap date.
- Added the SEO and generative-search positioning brief.

## Why

Cash-pay practices want the revenue from insured patients without taking on billing payroll and a second operating model. The page now leads with that problem and presents one autonomous front office as the answer.

## Checks

- Parsed the HTML and JSON-LD.
- Confirmed one H1 and the requested headline.
- Checked desktop and iPhone layouts in a real browser with no horizontal overflow.
- Verified calculator math and attributed email content.
- Ran `git diff --check`.