### PR TITLE
Fix Claims Native public edge release

### DIFF
--- a/.github/workflows/claimsnative-cloudflare.yml
+++ b/.github/workflows/claimsnative-cloudflare.yml
@@ -1,0 +1,67 @@
+name: Deploy Claims Native to Cloudflare
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "claimsnative/**"
+      - "scripts/build-claimsnative-pages.sh"
+      - "scripts/test-claimsnative-pages.sh"
+      - ".github/workflows/claimsnative-cloudflare.yml"
+  pull_request:
+    paths:
+      - "claimsnative/**"
+      - "scripts/build-claimsnative-pages.sh"
+      - "scripts/test-claimsnative-pages.sh"
+      - ".github/workflows/claimsnative-cloudflare.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: claimsnative-cloudflare-production
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Test the Pages build and redirect
+        run: bash scripts/test-claimsnative-pages.sh
+
+  deploy:
+    needs: test
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    environment: claimsnative-production
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Pages artifact
+        run: bash scripts/build-claimsnative-pages.sh .claimsnative-dist
+      - name: Deploy the Pages site
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.125.0"
+          command: pages deploy .claimsnative-dist --project-name=claimsnative --branch=main
+      - name: Deploy the www redirect
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' }}
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.125.0"
+          command: deploy --config claimsnative/cloudflare-www-redirect/wrangler.jsonc
+      - name: Report a missing deploy token
+        if: ${{ env.CLOUDFLARE_API_TOKEN == '' }}
+        run: |
+          echo "Cloudflare deploy skipped: add CLOUDFLARE_API_TOKEN to the claimsnative-production environment." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ Open `index.html` in any browser, edit, and refresh to see changes. No build ste
 ### Deployment
 The site auto-deploys to [atomandbits.com](https://atomandbits.com) when changes are pushed to the main branch.
 
+Claims Native builds from `claimsnative/` and deploys to
+[claimsnative.com](https://claimsnative.com) through the separate Cloudflare
+workflow. Run `bash scripts/test-claimsnative-pages.sh` before release. The
+workflow requires the `CLOUDFLARE_ACCOUNT_ID` repository variable and a narrow
+`CLOUDFLARE_API_TOKEN` secret in the `claimsnative-production` environment.
+
 ### Technical Notes
 - Responsive design using CSS Grid and Flexbox
 - Smooth scroll navigation with JavaScript

--- a/claimsnative/404.html
+++ b/claimsnative/404.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page not found | Claims Native</title>
+  <meta name="robots" content="noindex,follow">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,650&amp;family=Source+Sans+3:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
+  <link href="/claimsnative/site.css" rel="stylesheet">
+  <style>
+    main { min-height: calc(100vh - 156px); }
+    .not-found { padding: clamp(72px, 12vw, 140px) 0; }
+    .not-found-inner { max-width: 760px; }
+    .not-found-label {
+      margin: 0 0 18px;
+      color: var(--copper);
+      font-size: 0.78rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+    h1 {
+      margin: 0 0 22px;
+      color: var(--navy);
+      font-family: Fraunces, Georgia, serif;
+      font-size: clamp(3rem, 7vw, 5.5rem);
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+    }
+    .not-found p:not(.not-found-label) {
+      max-width: 620px;
+      margin: 0 0 30px;
+      color: var(--muted);
+      font-size: 1.15rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <nav class="nav" aria-label="Primary navigation">
+    <div class="nav-inner">
+      <a class="brand" href="/claimsnative/" aria-label="Claims Native home">
+        <strong>Claims Native</strong>
+        <span>by Atom &amp; Bits</span>
+      </a>
+      <div class="nav-links">
+        <a href="/claimsnative/90-day-pilot/">90-day pilot</a>
+        <a class="button" href="/claimsnative/insurance-opportunity/">See what insurance may be worth</a>
+      </div>
+    </div>
+  </nav>
+  <main id="main">
+    <section class="not-found">
+      <div class="container not-found-inner">
+        <p class="not-found-label">404 · Page not found</p>
+        <h1>This page is not here.</h1>
+        <p>Return to Claims Native or estimate what one insurance lane may be worth for your practice.</p>
+        <a class="button" href="/claimsnative/">Return to Claims Native</a>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="container footer-inner">
+      <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
+      <span><a href="https://atomandbits.com/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a></span>
+    </div>
+  </footer>
+</body>
+</html>

--- a/claimsnative/cloudflare-pages/_headers
+++ b/claimsnative/cloudflare-pages/_headers
@@ -3,7 +3,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   X-Frame-Options: DENY
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self' mailto:; frame-ancestors 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self' mailto:; frame-ancestors 'none'; img-src 'self' data:; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; connect-src 'self'
 
 /site.css
   Cache-Control: public, max-age=3600

--- a/claimsnative/cloudflare-pages/infrastructure.json
+++ b/claimsnative/cloudflare-pages/infrastructure.json
@@ -56,9 +56,19 @@
       "from_host": "www.claimsnative.com",
       "to": "https://claimsnative.com${path}",
       "status": 301,
-      "preserve_query_string": true
+      "preserve_query_string": true,
+      "worker": {
+        "name": "claims-native-www-redirect",
+        "config": "claimsnative/cloudflare-www-redirect/wrangler.jsonc"
+      }
     }
   ],
+  "release": {
+    "workflow": ".github/workflows/claimsnative-cloudflare.yml",
+    "account_id_variable": "CLOUDFLARE_ACCOUNT_ID",
+    "api_token_secret": "CLOUDFLARE_API_TOKEN",
+    "environment": "claimsnative-production"
+  },
   "legacy_redirects": [
     {
       "zone_id": "af05e25ce3f69fa37ec9cca2f386000a",

--- a/claimsnative/cloudflare-www-redirect/src/index.mjs
+++ b/claimsnative/cloudflare-www-redirect/src/index.mjs
@@ -1,0 +1,18 @@
+const SOURCE_HOST = "www.claimsnative.com";
+const CANONICAL_HOST = "claimsnative.com";
+
+export default {
+  fetch(request) {
+    const url = new URL(request.url);
+
+    if (url.hostname !== SOURCE_HOST) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    url.protocol = "https:";
+    url.hostname = CANONICAL_HOST;
+    url.port = "";
+
+    return Response.redirect(url.toString(), 301);
+  },
+};

--- a/claimsnative/cloudflare-www-redirect/test/redirect.test.mjs
+++ b/claimsnative/cloudflare-www-redirect/test/redirect.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import worker from "../src/index.mjs";
+
+test("redirects www paths and queries to the canonical host", async () => {
+  const response = await worker.fetch(
+    new Request("https://www.claimsnative.com/90-day-pilot/?source=partner")
+  );
+
+  assert.equal(response.status, 301);
+  assert.equal(
+    response.headers.get("location"),
+    "https://claimsnative.com/90-day-pilot/?source=partner"
+  );
+});
+
+test("fails closed for a host outside the configured route", async () => {
+  const response = await worker.fetch(
+    new Request("https://example.com/90-day-pilot/")
+  );
+
+  assert.equal(response.status, 404);
+  assert.equal(await response.text(), "Not found");
+});

--- a/claimsnative/cloudflare-www-redirect/wrangler.jsonc
+++ b/claimsnative/cloudflare-www-redirect/wrangler.jsonc
@@ -1,0 +1,14 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "claims-native-www-redirect",
+  "main": "src/index.mjs",
+  "compatibility_date": "2026-08-24",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [
+    {
+      "pattern": "www.claimsnative.com/*",
+      "zone_name": "claimsnative.com"
+    }
+  ]
+}

--- a/scripts/build-claimsnative-pages.sh
+++ b/scripts/build-claimsnative-pages.sh
@@ -19,6 +19,7 @@ fi
 mkdir -p "$output_dir"
 cp -R "$source_dir"/. "$output_dir"/
 rm -rf "$output_dir/cloudflare-pages"
+rm -rf "$output_dir/cloudflare-www-redirect"
 
 while IFS= read -r -d '' file; do
   perl -0pi -e 's#https://atomandbits\.com/claimsnative/#https://claimsnative.com/#g' "$file"

--- a/scripts/test-claimsnative-pages.sh
+++ b/scripts/test-claimsnative-pages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+output_dir="$test_dir/site"
+"$repo_dir/scripts/build-claimsnative-pages.sh" "$output_dir"
+
+test -f "$output_dir/404.html"
+test ! -e "$output_dir/cloudflare-www-redirect"
+grep -Fq "Page not found | Claims Native" "$output_dir/404.html"
+grep -Fq "https://static.cloudflareinsights.com" "$output_dir/_headers"
+grep -Fq "connect-src 'self'" "$output_dir/_headers"
+grep -Fq "CLOUDFLARE_API_TOKEN" "$repo_dir/.github/workflows/claimsnative-cloudflare.yml"
+grep -Fq "CLOUDFLARE_ACCOUNT_ID" "$repo_dir/.github/workflows/claimsnative-cloudflare.yml"
+
+node --test "$repo_dir/claimsnative/cloudflare-www-redirect/test/redirect.test.mjs"


### PR DESCRIPTION
## What changed

- add a branded 404 so unknown paths return 404
- allow the Cloudflare analytics beacon in the site CSP
- add a tested Worker that redirects www paths and queries to the apex domain
- add a Cloudflare Pages release workflow and scoped credential names
- record the edge and release configuration

## Why

The apex site was live, but www returned 522, unknown paths returned the homepage, the analytics beacon was blocked, and Pages releases were manual.

## Checks

- bash scripts/test-claimsnative-pages.sh
- Wrangler redirect dry run
- live apex, four buyer routes, robots, sitemap, 404, and www redirect checks
- browser check of the public page and www redirect

The live site and redirect were deployed from this branch. The GitHub workflow still needs a narrow CLOUDFLARE_API_TOKEN environment secret before CI can deploy.