### PR TITLE
Add a login path to the Claims Native site

### DIFF
--- a/claimsnative/90-day-pilot/index.html
+++ b/claimsnative/90-day-pilot/index.html
@@ -678,6 +678,7 @@
         <a href="#fit">Fit</a>
         <a href="#plan">90 days</a>
         <a href="#proof">Proof</a>
+        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
         <a class="button" href="/claimsnative/insurance-opportunity/">See what insurance may be worth</a>
       </div>
     </div>
@@ -965,7 +966,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 </body>

--- a/claimsnative/chiropractors/index.html
+++ b/claimsnative/chiropractors/index.html
@@ -556,6 +556,7 @@
         <a href="#workflow">Workflow</a>
         <a href="#rules">Review rules</a>
         <a href="#outputs">Outputs</a>
+        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
         <a class="button" href="/claimsnative/insurance-opportunity/">See what insurance may be worth</a>
       </div>
     </div>
@@ -747,7 +748,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="/claimsnative/">Claims Native</a> · <a href="/claimsnative/90-day-pilot/">90-day pilot</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/claimsnative/">Claims Native</a> · <a href="/claimsnative/90-day-pilot/">90-day pilot</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 </body>

--- a/claimsnative/index.html
+++ b/claimsnative/index.html
@@ -392,6 +392,7 @@
       </a>
       <div class="nav-links">
         <a href="/claimsnative/90-day-pilot/">90-day pilot</a>
+        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
         <a class="button" href="/claimsnative/insurance-opportunity/">See what insurance may be worth</a>
       </div>
     </div>
@@ -494,7 +495,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 </body>

--- a/claimsnative/insurance-opportunity/index.html
+++ b/claimsnative/insurance-opportunity/index.html
@@ -505,6 +505,7 @@
       <div class="nav-links">
         <a href="#calculator">Calculator</a>
         <a href="/claimsnative/90-day-pilot/" data-pilot-cta>90-day pilot</a>
+        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
       </div>
     </div>
   </nav>
@@ -715,7 +716,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="/claimsnative/">Claims Native home</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/claimsnative/">Claims Native home</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 


### PR DESCRIPTION
## What changed

- Add a Demo login button to each Claims Native funnel page.
- Add the same login path to every page footer.
- Keep the demo out of search results through the app edge.

## Why

Prospects can now move from the public product story into the working synthetic app.

## Checks

- `bash scripts/test-claimsnative-pages.sh`
- `git diff --check`