### PR TITLE
Use the Claims Native login hostname

### DIFF
--- a/claimsnative/90-day-pilot/index.html
+++ b/claimsnative/90-day-pilot/index.html
@@ -678,7 +678,7 @@
         <a href="#fit">Fit</a>
         <a href="#plan">90 days</a>
         <a href="#proof">Proof</a>
-        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
+        <a class="button secondary" href="https://login.claimsnative.com/" rel="nofollow">Demo login</a>
         <a class="button" href="/claimsnative/insurance-opportunity/">See what insurance may be worth</a>
       </div>
     </div>
@@ -966,7 +966,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://login.claimsnative.com/" rel="nofollow">Demo login</a> · <a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 </body>

--- a/claimsnative/chiropractors/index.html
+++ b/claimsnative/chiropractors/index.html
@@ -556,7 +556,7 @@
         <a href="#workflow">Workflow</a>
         <a href="#rules">Review rules</a>
         <a href="#outputs">Outputs</a>
-        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
+        <a class="button secondary" href="https://login.claimsnative.com/" rel="nofollow">Demo login</a>
         <a class="button" href="/claimsnative/insurance-opportunity/">See what insurance may be worth</a>
       </div>
     </div>
@@ -748,7 +748,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/claimsnative/">Claims Native</a> · <a href="/claimsnative/90-day-pilot/">90-day pilot</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://login.claimsnative.com/" rel="nofollow">Demo login</a> · <a href="/claimsnative/">Claims Native</a> · <a href="/claimsnative/90-day-pilot/">90-day pilot</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 </body>

--- a/claimsnative/index.html
+++ b/claimsnative/index.html
@@ -392,7 +392,7 @@
       </a>
       <div class="nav-links">
         <a href="/claimsnative/90-day-pilot/">90-day pilot</a>
-        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
+        <a class="button secondary" href="https://login.claimsnative.com/" rel="nofollow">Demo login</a>
         <a class="button" href="/claimsnative/insurance-opportunity/">See what insurance may be worth</a>
       </div>
     </div>
@@ -495,7 +495,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://login.claimsnative.com/" rel="nofollow">Demo login</a> · <a href="/">Atom &amp; Bits</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 </body>

--- a/claimsnative/insurance-opportunity/index.html
+++ b/claimsnative/insurance-opportunity/index.html
@@ -505,7 +505,7 @@
       <div class="nav-links">
         <a href="#calculator">Calculator</a>
         <a href="/claimsnative/90-day-pilot/" data-pilot-cta>90-day pilot</a>
-        <a class="button secondary" href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a>
+        <a class="button secondary" href="https://login.claimsnative.com/" rel="nofollow">Demo login</a>
       </div>
     </div>
   </nav>
@@ -716,7 +716,7 @@
   <footer>
     <div class="container footer-inner">
       <span>Claims Native is an Atom &amp; Bits product · Chattanooga, Tennessee</span>
-      <span><a href="https://demo.claimsnative.com/login" rel="nofollow">Demo login</a> · <a href="/claimsnative/">Claims Native home</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
+      <span><a href="https://login.claimsnative.com/" rel="nofollow">Demo login</a> · <a href="/claimsnative/">Claims Native home</a> · <a href="mailto:Ian@atomandbits.com">Ian@atomandbits.com</a> · <a href="/privacy-policy.html">Privacy</a></span>
     </div>
   </footer>
 


### PR DESCRIPTION
## What changed

- Point each Demo login link at `login.claimsnative.com`.

## Why

The login hostname gives prospects a clear app path and avoids the earlier local DNS cache on the demo alias.

## Checks

- `bash scripts/test-claimsnative-pages.sh`
- `git diff --check`